### PR TITLE
Set value of the underlying input

### DIFF
--- a/inputosaurus.js
+++ b/inputosaurus.js
@@ -431,8 +431,8 @@
 				widget._renderTags();
 			}
 			
-			widget._resizeInput();
 			widget.elements.input.val('');
+			widget._resizeInput();
 			
 		},
 		

--- a/inputosaurus.js
+++ b/inputosaurus.js
@@ -52,7 +52,9 @@
 
 			// manipulate and return the input value after parseInput() parsing
 			// the array of tag names is passed and expected to be returned as an array after manipulation
-			parseHook : null
+			parseHook : null,
+			
+			enableSetValue: false
 		},
 
 		_create: function() {
@@ -412,24 +414,34 @@
 			$(ev.currentTarget).parent()[ev.type === 'focusout' ? 'removeClass' : 'addClass']('inputosaurus-selected');
 		},
 
-		refresh : function() {
-			var delim = this.options.outputDelimiter,
-				val = this.element.val(),
+		refresh : function(ev) {
+			var widget = (ev && ev.data.widget) || this,
+				delim = widget.options.outputDelimiter,
+				val = widget.element.val(),
 				values = [];
 			
-			values.push(val);
-			delim && (values = val.split(delim));
+			widget._chosenValues = [];
 
-			if(values.length){
-				this._chosenValues = [];
-
-				$.isFunction(this.options.parseHook) && (values = this.options.parseHook(values));
-
-				this._setChosen(values);
-				this._renderTags();
-				this.elements.input.val('');
-				this._resizeInput();
+			if(val.length){
+				values.push(val);
+				delim && (values = val.split(delim));
+				$.isFunction(widget.options.parseHook) && (values = widget.options.parseHook(values));
+				widget._setChosen(values);	
+			} else {
+				widget._renderTags();
 			}
+			
+			widget._resizeInput();
+			widget.elements.input.val('');
+			
+		},
+		
+		_inputChanged : function(ev){
+			var widget = (ev && ev.data.widget) || this;
+			if (widget.options.enableSetValue){
+				widget.refresh(ev);
+			}
+			
 		},
 
 		_attachEvents : function() {
@@ -447,6 +459,9 @@
 			this.elements.ul.on('focus.inputosaurus', 'a', {widget : widget}, this._tagFocus);
 			this.elements.ul.on('blur.inputosaurus', 'a', {widget : widget}, this._tagFocus);
 			this.elements.ul.on('keydown.inputosaurus', 'a', {widget : widget}, this._tagKeypress);
+		
+			this.element.on('change', {widget:widget}, this._inputChanged);
+
 		},
 
 		_destroy: function() {

--- a/tests/index.html
+++ b/tests/index.html
@@ -138,6 +138,44 @@
 				ok(instance._chosenValues.length == 0, 'final value count correct');
 			});
 
+			test('clear', function(){
+				instance.element.val('sprout');
+				instance.refresh();
+				ok(instance._chosenValues.length == 1, 'initial value count correct');
+				
+				instance.options.enableSetValue = true;
+				
+				instance.element.val('').change();
+				ok(instance._chosenValues.length == 0, 'choosen values should be empty after clear');
+			});
+			
+			test('set more values', function(){
+				instance.element.val('sprout');
+				instance.refresh();
+				ok(instance._chosenValues.length == 1, 'initial value count correct');
+				
+				instance.options.enableSetValue = true;
+				
+				instance.element.val('chicago,il').change();				
+				ok(instance._chosenValues.length === 2, 'proper value count');
+				ok(instance._chosenValues[0].value === 'chicago', 'proper value string 0');
+				ok(instance._chosenValues[1].value === 'il', 'proper value string 1');
+				
+			});
+			
+			test('set values not enabled', function(){
+				instance.element.val('sprout');
+				instance.refresh();
+				ok(instance._chosenValues.length == 1, 'initial value count correct');
+				
+				instance.options.enableSetValue = false;
+				
+				instance.element.val('chicago,il').change();				
+				ok(instance._chosenValues.length === 1, 'proper value count');
+				ok(instance._chosenValues[0].value === 'sprout', 'proper value string 0');
+				
+			});
+			
 		})(jQuery);
 	</script>
 </body>


### PR DESCRIPTION
The user can set the value of the underlying input, what triggers
refresh. This behavior can be controlled by enableSetValue option.
If true, changes of the underlying input reflected on widget.

I refactored the refresh method during the development, there were redundant calls of _renderTags function. 

Usage: $("#saurus").val('').change();

Added some tests as well to cover the new feature.
