### PR TITLE
issues#24 fix for changed autosuggest class name in jqueryui 1.11.0

### DIFF
--- a/inputosaurus.js
+++ b/inputosaurus.js
@@ -181,7 +181,7 @@
 
 			if(delimiterFound !== false){
 				values = val.split(delimiterFound);
-			} else if(!ev || ev.which === $.ui.keyCode.ENTER && !$('.ui-menu-item .ui-state-focus').size() && !$('#ui-active-menuitem').size()){
+			} else if(!ev || ev.which === $.ui.keyCode.ENTER && !$('.ui-menu-item.ui-state-focus').size() && !$('.ui-menu-item .ui-state-focus').size() && !$('#ui-active-menuitem').size()){
 				values.push(val);
 				ev && ev.preventDefault();
 


### PR DESCRIPTION
The css class name for the autosuggest changed in recent jqueryui versions. That caused an error in the activateFinalResult method.
