### PR TITLE
Perform a ajax request after new/change/removed tag

### DIFF
--- a/inputosaurus.js
+++ b/inputosaurus.js
@@ -417,7 +417,7 @@
 			if(arguments[1] && (arguments[1].type == 'dblclick' && value == '')){
 				return false;
 			}
-			var val = this.element.val();
+			var val = this.element.val().replace(/,\s*/g,',');
 
 			if(val !== value){
 				this.element.val(value);
@@ -540,6 +540,17 @@
 					type:'POST'
 				},requestTags);
 
+				var extraValues = this.element.data('submit-values');
+				if(typeof extraValues == 'string' && /\{*/.test(extraValues)){
+					extraValues = $.parseJSON(extraValues.replace(/\'/g,'\"'));
+				}
+
+				if(!$.isEmptyObject(extraValues)){
+					for(v in extraValues){
+						opts.data[v] = extraValues[v];
+					}
+				}
+
 				opts.data.tag_list = this.element.val();
 
 				$.ajax(opts);
@@ -548,4 +559,4 @@
 	};
 
 	$.widget("ui.inputosaurus", inputosaurustext);
-})(jQuery);
+})($ || jQuery);


### PR DESCRIPTION
Added new feature to perform a **ajax request** in each change on input value of tags. This request use **data-submit-values** (if you input text has this) HTML5 attribute on data jQuery ajax to send params to a server. Use The documentation on **gh-pages** branch was changed with new option and your description.
